### PR TITLE
use  PyYAML instead of yaml

### DIFF
--- a/Dockerfile.inference
+++ b/Dockerfile.inference
@@ -1,7 +1,7 @@
 ARG CUDA_RELEASE=11.6.2-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:${CUDA_RELEASE} AS base
 ENV DEBIAN_FRONTEND=noninteractive
-ADD * /root/
+ADD . /root
 WORKDIR /root
 
 RUN apt update && apt upgrade -y && \

--- a/Dockerfile.inference
+++ b/Dockerfile.inference
@@ -7,6 +7,6 @@ WORKDIR /root
 RUN apt update && apt upgrade -y && \
     apt update && apt install -y python3 python3-pip && \
     pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements/inference.txt
+    pip3 install --no-cache-dir -r /root/requirements/inference.txt
 
 CMD ["python3", "/root/inference.py"]

--- a/requirements/inference.txt
+++ b/requirements/inference.txt
@@ -1,6 +1,6 @@
 fastapi==0.85.1
 uvicorn==0.19.0
 aiohttp==3.8.3
-yaml==5.4.1
+pyyaml==5.4.1
 transformers==4.25.1
 torch


### PR DESCRIPTION
yaml is a built in library (at least on 3.10), so it will return an error when trying to install it, plus in the gateway file; you use pyyaml correctly